### PR TITLE
SpawnNormalOffset applied to base and fighter template

### DIFF
--- a/lvs_base/lua/entities/lvs_base/init.lua
+++ b/lvs_base/lua/entities/lvs_base/init.lua
@@ -26,7 +26,7 @@ function ENT:SpawnFunction( ply, tr, ClassName )
 
 	local ent = ents.Create( ClassName )
 	ent:StoreCPPI( ply )
-	ent:SetPos( tr.HitPos + tr.HitNormal * 15 )
+	ent:SetPos( tr.HitPos + tr.HitNormal * ent.SpawnNormalOffset )
 	ent:SetAngles( Angle(0, ply:EyeAngles().y, 0 ) )
 	ent:Spawn()
 	ent:Activate()

--- a/lvs_base/lua/entities/lvs_base/shared.lua
+++ b/lvs_base/lua/entities/lvs_base/shared.lua
@@ -22,6 +22,8 @@ ENT.AITEAM = 0
 ENT.MaxHealth = 100
 ENT.MaxShield = 0
 
+ENT.SpawnNormalOffset = 15
+
 function ENT:AddDT( type, name, data )
 	if not self.DTlist then self.DTlist = {} end
 

--- a/lvs_planes/lua/entities/lvs_plane_template/shared.lua
+++ b/lvs_planes/lua/entities/lvs_plane_template/shared.lua
@@ -9,6 +9,8 @@ ENT.Category = "[LVS] *your category*"
 ENT.Spawnable			= false -- set to "true" to make it spawnable
 ENT.AdminSpawnable		= false
 
+ENT.SpawnNormalOffset = 15 -- spawn normal offset, raise to prevent spawning into the ground
+
 ENT.MDL = "models/props_wasteland/laundry_cart001.mdl" -- model forward direction must be facing to X+
 --[[
 ENT.GibModels = {


### PR DESCRIPTION
Replaces the arbitrary 15 offset relative to the HitNormal in the SpawnFunction.
Makes it so you don't have to override the SpawnFunc in every plane you make.