### PR TITLE
Fix binding to spawn menu key not working

### DIFF
--- a/lvs_base/lua/lvs_framework/autorun/lvs_player.lua
+++ b/lvs_base/lua/lvs_framework/autorun/lvs_player.lua
@@ -203,7 +203,7 @@ if CLIENT then
 
 	hook.Add( "OnSpawnMenuOpen", "!!!lvs_keyblocker", function()
 		local ply = LocalPlayer()
-		if not IsValid( ply ) then return end
+		if not IsValid( ply ) or ply._lvsDisableSpawnMenu then return end
 		ply:lvsSetInputDisabled( true )
 	end )
 
@@ -215,7 +215,7 @@ if CLIENT then
 
 	hook.Add( "OnSpawnMenuClose", "!!!lvs_keyblocker", function()
 		local ply = LocalPlayer()
-		if not IsValid( ply ) then return end
+		if not IsValid( ply ) or ply._lvsDisableSpawnMenu then return end
 		ply:lvsSetInputDisabled( false )
 	end )
 


### PR DESCRIPTION
Even though the spawn menu is disabled when setting a control to use the same key as your spawn menu, the OnSpawnMenuOpen hook is still disabling input.
Tested this change with both `ply._lvsDisableSpawnMenu = nil` and `ply._lvsDisableSpawnMenu = true` and both work as expected