### PR TITLE
Fix unsecured netmessage

### DIFF
--- a/lua/entities/lvs_base_doorhandler.lua
+++ b/lua/entities/lvs_base_doorhandler.lua
@@ -83,6 +83,7 @@ if SERVER then
 		local ent = net.ReadEntity()
 
 		if not IsValid( ent ) or not ent._UseTargetAllowed or not ent.UseRange or ply:InVehicle() then return end
+		if hook.Call("PlayerUse", nil, ply, ent) == false then return end
 
 		local Range = ent.UseRange * 2
 


### PR DESCRIPTION
This netmessage allows modified clients to interact with any entity within range, even if they are not part of LVS and would normaly be blocked by another addon using the PlayerUse Hook. This fix is necessary as this hook is the only way to restrict interaction with map entities.