### PR TITLE
feat(hud): RPM Indicator for over-rpm-ing

### DIFF
--- a/lua/entities/lvs_base_wheeldrive/cl_hud.lua
+++ b/lua/entities/lvs_base_wheeldrive/cl_hud.lua
@@ -43,14 +43,30 @@ function ENT:LVSHudPaintInfoText( X, Y, W, H, ScrX, ScrY, ply )
 
 	surface.SetDrawColor( 0, 0, 0, 200 )
 	surface.DrawTexturedRectRotated( hX + 4, hY + 1, H * 0.5, H * 0.5, 0 )
-	surface.SetDrawColor( color_white )
+
+	if ( self:IsManualTransmission() ) then
+		local engine = self:GetEngine()
+		if ( not IsValid( engine ) or not isnumber( self.EngineMaxRPM ) ) then return end
+
+		local RPM = engine:GetRPM() / self.EngineMaxRPM
+		if ( RPM > 0.95 ) then
+			local OverRev = math.min( ( RPM - 0.95 ) * 10, 1 )
+
+			surface.SetDrawColor( 255, 255 - (255 * OverRev), 0, 255 )
+		else
+			surface.SetDrawColor( 255, 255, 255, 255 )
+		end
+	else
+		surface.SetDrawColor( color_white )
+	end
+
 	surface.DrawTexturedRectRotated( hX + 2, hY - 1, H * 0.5, H * 0.5, 0 )
 
 	if not self:GetEngineActive() then
 		draw.SimpleText( "X" , "LVS_FONT",  hX, hY, Color(0,0,0,255), TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER )
 	else
 		oldThrottleActive = false
-	
+
 		local Reverse = self:GetReverse()
 
 		if oldReverse ~= Reverse then

--- a/lua/entities/lvs_base_wheeldrive/cl_hud.lua
+++ b/lua/entities/lvs_base_wheeldrive/cl_hud.lua
@@ -48,9 +48,12 @@ function ENT:LVSHudPaintInfoText( X, Y, W, H, ScrX, ScrY, ply )
 
 	if ( IsManual ) then
 		local Engine = self:GetEngine()
-		if ( not IsValid( Engine ) or not isnumber( self.EngineMaxRPM ) ) then return end
+		if ( not IsValid( Engine ) or not isnumber( self.EngineMaxRPM ) or self.EngineMaxRPM <= 0 ) then
+			surface.SetDrawColor( color_white )
+			return
+		end
 
-		local RPM = engine:GetRPM() / self.EngineMaxRPM
+		local RPM = Engine:GetRPM() / self.EngineMaxRPM
 		if ( RPM > 0.95 ) then
 			local OverRev = math.min( ( RPM - 0.95 ) * 10, 1 )
 

--- a/lua/entities/lvs_base_wheeldrive/cl_hud.lua
+++ b/lua/entities/lvs_base_wheeldrive/cl_hud.lua
@@ -44,9 +44,11 @@ function ENT:LVSHudPaintInfoText( X, Y, W, H, ScrX, ScrY, ply )
 	surface.SetDrawColor( 0, 0, 0, 200 )
 	surface.DrawTexturedRectRotated( hX + 4, hY + 1, H * 0.5, H * 0.5, 0 )
 
-	if ( self:IsManualTransmission() ) then
-		local engine = self:GetEngine()
-		if ( not IsValid( engine ) or not isnumber( self.EngineMaxRPM ) ) then return end
+	local IsManual = self:IsManualTransmission()
+
+	if ( IsManual ) then
+		local Engine = self:GetEngine()
+		if ( not IsValid( Engine ) or not isnumber( self.EngineMaxRPM ) ) then return end
 
 		local RPM = engine:GetRPM() / self.EngineMaxRPM
 		if ( RPM > 0.95 ) then
@@ -75,7 +77,6 @@ function ENT:LVSHudPaintInfoText( X, Y, W, H, ScrX, ScrY, ply )
 			WaveScale = 1
 		end
 
-		local IsManual = self:IsManualTransmission()
 		local Gear = self:GetGear()
 
 		if oldGear ~= Gear then


### PR DESCRIPTION
This pull request adds a visual indicator to the HUD for vehicles with manual transmission, highlighting when the engine is approaching or exceeding the recommended RPM range. The change ensures that players receive visual feedback (a color change) when over-revving the engine, helping them shift gears at the right time.

**HUD improvements for manual transmission vehicles:**

* Added logic in `ENT:LVSHudPaintInfoText` (`cl_hud.lua`) to change the HUD color when the engine RPM exceeds 95% of the maximum, providing a yellow-to-red warning for over-revving in manual transmission vehicles.